### PR TITLE
Fix support for composer 2.2.1+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,5 +39,10 @@
 		"vimeo/psalm": "^4.10",
 		"phpstan/phpstan": "^0.12.99",
 		"mediawiki/mediawiki-codesniffer": "37.0.0"
+	},
+	"config": {
+		"allow-plugins": {
+			"composer/installers": true
+		}
 	}
 }


### PR DESCRIPTION
Composer 2.2.1+ requires plugins to be allowed