### PR TITLE
Fix tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   test:
     name: "PHPUnit: MW ${{ matrix.mw }}, PHP ${{ matrix.php }}"
+    continue-on-error: ${{ matrix.experimental }}
 
     strategy:
       fail-fast: false
@@ -14,8 +15,25 @@ jobs:
         include:
           - mw: 'REL1_35'
             php: 8.0
+            experimental: false
           - mw: 'REL1_39'
             php: 8.1
+            experimental: false
+          - mw: 'REL1_40'
+            php: 8.1
+            experimental: false
+          - mw: 'REL1_41'
+            php: 8.2
+            experimental: false
+          - mw: 'REL1_42'
+            php: 8.2
+            experimental: false
+          - mw: 'REL1_43'
+            php: 8.3
+            experimental: false
+          - mw: 'master'
+            php: 8.4
+            experimental: true
 
     runs-on: ubuntu-latest
 
@@ -33,7 +51,7 @@ jobs:
 
       - name: Cache MediaWiki
         id: cache-mediawiki
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             mediawiki
@@ -42,7 +60,7 @@ jobs:
           key: mw_${{ matrix.mw }}-php${{ matrix.php }}
 
       - name: Cache Composer cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache
           key: composer-php${{ matrix.php }}
@@ -52,7 +70,7 @@ jobs:
         working-directory: ~
         run: curl https://gist.githubusercontent.com/JeroenDeDauw/49a3858653ff4b5be7ec849019ede06c/raw/installMediaWiki.sh | bash -s ${{ matrix.mw }} ExternalContent
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           path: mediawiki/extensions/ExternalContent
 
@@ -66,19 +84,18 @@ jobs:
 
       - name: Run PHPUnit
         run: php tests/phpunit/phpunit.php -c extensions/ExternalContent/
-        if: matrix.php != 7.4
 
       - name: Run PHPUnit with code coverage
         run: php tests/phpunit/phpunit.php -c extensions/ExternalContent/ --coverage-clover coverage.xml
-        if: matrix.php == 7.4
+        if: matrix.mw == 'master'
 
       - name: Upload code coverage
         run: bash <(curl -s https://codecov.io/bash)
-        if: matrix.php == 7.4
+        if: matrix.mw == 'master'
 
       - name: Run parser tests
         run: php tests/parser/parserTests.php --file=extensions/ExternalContent/tests/parser/parserTests.txt
-        if: matrix.mw == 'REL1_39'
+        if: matrix.mw >= 'REL1_43'
 
   static-analysis:
     name: "Static Analysis"
@@ -99,7 +116,7 @@ jobs:
 
       - name: Cache MediaWiki
         id: cache-mediawiki
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             mediawiki
@@ -108,7 +125,7 @@ jobs:
           key: mw_static_analysis
 
       - name: Cache Composer cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache
           key: composer_static_analysis
@@ -118,7 +135,7 @@ jobs:
         working-directory: ~
         run: curl https://gist.githubusercontent.com/JeroenDeDauw/49a3858653ff4b5be7ec849019ede06c/raw/installMediaWiki.sh | bash -s REL1_36 ExternalContent
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           path: mediawiki/extensions/ExternalContent
 
@@ -154,7 +171,7 @@ jobs:
 
       - name: Cache MediaWiki
         id: cache-mediawiki
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             mediawiki
@@ -163,7 +180,7 @@ jobs:
           key: mw_static_analysis
 
       - name: Cache Composer cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache
           key: composer_static_analysis
@@ -173,7 +190,7 @@ jobs:
         working-directory: ~
         run: curl https://gist.githubusercontent.com/JeroenDeDauw/49a3858653ff4b5be7ec849019ede06c/raw/installMediaWiki.sh | bash -s REL1_36 ExternalContent
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           path: mediawiki/extensions/ExternalContent
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - mw: 'REL1_35'
-            php: 8.0
-            experimental: false
           - mw: 'REL1_39'
             php: 8.1
             experimental: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,10 +62,14 @@ jobs:
           path: ~/.composer/cache
           key: composer-php${{ matrix.php }}
 
+      - uses: actions/checkout@v4
+        with:
+          path: EarlyCopy
+
       - name: Install MediaWiki
         if: steps.cache-mediawiki.outputs.cache-hit != 'true'
         working-directory: ~
-        run: curl https://gist.githubusercontent.com/JeroenDeDauw/49a3858653ff4b5be7ec849019ede06c/raw/installMediaWiki.sh | bash -s ${{ matrix.mw }} ExternalContent
+        run: bash EarlyCopy/.github/workflows/installMediaWiki.sh ${{ matrix.mw }} ExternalContent
 
       - uses: actions/checkout@v4
         with:
@@ -95,7 +99,13 @@ jobs:
         if: matrix.mw >= 'REL1_43'
 
   static-analysis:
-    name: "Static Analysis"
+    name: "Static Analysis: MW ${{ matrix.mw }}, PHP ${{ matrix.php }}"
+
+    strategy:
+      matrix:
+        include:
+          - mw: 'REL1_43'
+            php: '8.3'
 
     runs-on: ubuntu-latest
 
@@ -107,7 +117,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: ${{ matrix.php }}
           extensions: mbstring
           tools: composer, cs2pr
 
@@ -127,10 +137,14 @@ jobs:
           path: ~/.composer/cache
           key: composer_static_analysis
 
+      - uses: actions/checkout@v4
+        with:
+          path: EarlyCopy
+
       - name: Install MediaWiki
         if: steps.cache-mediawiki.outputs.cache-hit != 'true'
         working-directory: ~
-        run: curl https://gist.githubusercontent.com/JeroenDeDauw/49a3858653ff4b5be7ec849019ede06c/raw/installMediaWiki.sh | bash -s REL1_36 ExternalContent
+        run: bash EarlyCopy/.github/workflows/installMediaWiki.sh ${{ matrix.mw }} ExternalContent
 
       - uses: actions/checkout@v4
         with:
@@ -150,7 +164,13 @@ jobs:
 
 
   code-style:
-    name: "Code style"
+    name: "Code style: MW ${{ matrix.mw }}, PHP ${{ matrix.php }}"
+
+    strategy:
+      matrix:
+        include:
+          - mw: 'REL1_43'
+            php: '8.3'
 
     runs-on: ubuntu-latest
 
@@ -162,7 +182,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: ${{ matrix.php }}
           extensions: mbstring, intl, php-ast
           tools: composer
 
@@ -182,10 +202,14 @@ jobs:
           path: ~/.composer/cache
           key: composer_static_analysis
 
+      - uses: actions/checkout@v4
+        with:
+          path: EarlyCopy
+
       - name: Install MediaWiki
         if: steps.cache-mediawiki.outputs.cache-hit != 'true'
         working-directory: ~
-        run: curl https://gist.githubusercontent.com/JeroenDeDauw/49a3858653ff4b5be7ec849019ede06c/raw/installMediaWiki.sh | bash -s REL1_36 ExternalContent
+        run: bash EarlyCopy/.github/workflows/installMediaWiki.sh ${{ matrix.mw }} ExternalContent
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/installMediaWiki.sh
+++ b/.github/workflows/installMediaWiki.sh
@@ -1,0 +1,45 @@
+#! /bin/bash
+
+set -ex
+
+MW_BRANCH=$1
+EXTENSION_NAME=$2
+
+wget "https://github.com/wikimedia/mediawiki/archive/refs/heads/$MW_BRANCH.tar.gz" -nv
+
+tar -zxf $MW_BRANCH.tar.gz
+mv mediawiki-$MW_BRANCH mediawiki
+
+cd mediawiki
+
+composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
+
+php maintenance/install.php \
+	--dbtype sqlite \
+	--dbuser root \
+	--dbname mw \
+	--dbpath "$(pwd)" \
+	--scriptpath="" \
+	--pass AdminPassword WikiName AdminUser
+
+echo 'error_reporting(E_ALL| E_STRICT);' >> LocalSettings.php
+echo 'ini_set("display_errors", 1);' >> LocalSettings.php
+echo '$wgShowExceptionDetails = true;' >> LocalSettings.php
+echo '$wgShowDBErrorBacktrace = true;' >> LocalSettings.php
+echo '$wgDevelopmentWarnings = true;' >> LocalSettings.php
+
+echo 'wfLoadExtension( "'$EXTENSION_NAME'" );' >> LocalSettings.php
+
+cat <<EOT >> composer.local.json
+{
+  	"require": {},
+	"extra": {
+		"merge-plugin": {
+			"merge-dev": true,
+			"include": [
+				"extensions/$EXTENSION_NAME/composer.json"
+			]
+		}
+	}
+}
+EOT

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ Parameters: none
 
 Platform requirements:
 
-* [PHP] 8.0 or later (tested up to 8.1)
-* [MediaWiki] 1.35 or later (tested up to 1.39 and master)
+* [PHP] 8.0 or later (tested up to 8.3)
+* [MediaWiki] 1.35 or later (tested up to 1.43 and master)
 
 The recommended way to install External Content is using [Composer] with
 [MediaWiki's built-in support for Composer][Composer install].

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,9 +6,6 @@
 		<testsuite name="Integration">
 			<directory>tests/Integration</directory>
 		</testsuite>
-		<testsuite name="System">
-			<directory>tests/System</directory>
-		</testsuite>
 	</testsuites>
 	<filter>
 		<whitelist addUncoveredFilesFromWhitelist="true">

--- a/tests/Integration/BitbucketFunctionIntegrationTest.php
+++ b/tests/Integration/BitbucketFunctionIntegrationTest.php
@@ -9,6 +9,7 @@ use FileFetcher\StubFileFetcher;
 use ProfessionalWiki\ExternalContent\Tests\TestEnvironment;
 
 /**
+ * @group Database
  * @covers \ProfessionalWiki\ExternalContent\EntryPoints\BitbucketFunction
  * @covers \ProfessionalWiki\ExternalContent\EntryPoints\MediaWikiHooks
  * @covers \ProfessionalWiki\ExternalContent\Adapters\EmbedPresenter\ParserFunctionEmbedPresenter

--- a/tests/Integration/EmbedFunctionIntegrationTest.php
+++ b/tests/Integration/EmbedFunctionIntegrationTest.php
@@ -10,6 +10,7 @@ use MediaWiki\MediaWikiServices;
 use ProfessionalWiki\ExternalContent\Tests\TestEnvironment;
 
 /**
+ * @group Database
  * @covers \ProfessionalWiki\ExternalContent\EntryPoints\EmbedFunction
  * @covers \ProfessionalWiki\ExternalContent\EntryPoints\MediaWikiHooks
  * @covers \ProfessionalWiki\ExternalContent\Adapters\EmbedPresenter\ParserFunctionEmbedPresenter
@@ -60,12 +61,12 @@ class EmbedFunctionIntegrationTest extends ExternalContentIntegrationTestCase {
 		// Since the category name depends on the wiki language, we need to skip this test when it is not English.
 		if ( MediaWikiServices::getInstance()->getContentLanguage()->getCode() === 'en' ) {
 			$this->assertSame(
-				[ 'Pages_with_external_content' => '', 'Pages_with_broken_external_content' => '' ],
-				$parser->getOutput()->getCategories()
+				[ 'Pages_with_external_content', 'Pages_with_broken_external_content' ],
+				$parser->getOutput()->getCategoryNames()
 			);
 		}
 
-		$this->assertCount( 2, $parser->getOutput()->getCategories() );
+		$this->assertCount( 2, $parser->getOutput()->getCategoryNames() );
 	}
 
 	public function testGitHubNormalization(): void {

--- a/tests/TestEnvironment.php
+++ b/tests/TestEnvironment.php
@@ -21,7 +21,7 @@ class TestEnvironment {
 		return null;
 	}
 
-	public function parse( string $textToParse, Title $contextPage = null ): string {
+	public function parse( string $textToParse, ?Title $contextPage = null ): string {
 		return MediaWikiServices::getInstance()->getParser()
 			->parse(
 				$textToParse,

--- a/tests/Unit/Adapters/ParserFunctionEmbedPresenterTest.php
+++ b/tests/Unit/Adapters/ParserFunctionEmbedPresenterTest.php
@@ -37,10 +37,13 @@ class ParserFunctionEmbedPresenterTest extends TestCase {
 		$presenter->showError( 'my-error' );
 		$parserFunctionReturnValue = $presenter->getParserFunctionReturnValue();
 
-		$this->assertStringContainsEither(
-			'<div class="errorbox">', // MW 35-37
-			'mw-message-box-error', // MW 39+
-			$parserFunctionReturnValue[0]
+		$this->assertThat(
+			$parserFunctionReturnValue[0],
+			$this->logicalOr(
+				$this->stringContains('<div class="errorbox">'),
+				$this->stringContains('mw-message-box-error'),
+				$this->stringContains('cdx-message--error')
+			)
 		);
 
 		$this->assertTrue( $parserFunctionReturnValue['noparse'] );

--- a/tests/Unit/Adapters/ParserFunctionEmbedPresenterTest.php
+++ b/tests/Unit/Adapters/ParserFunctionEmbedPresenterTest.php
@@ -40,9 +40,9 @@ class ParserFunctionEmbedPresenterTest extends TestCase {
 		$this->assertThat(
 			$parserFunctionReturnValue[0],
 			$this->logicalOr(
-				$this->stringContains('<div class="errorbox">'),
-				$this->stringContains('mw-message-box-error'),
-				$this->stringContains('cdx-message--error')
+				$this->stringContains( '<div class="errorbox">' ),
+				$this->stringContains( 'mw-message-box-error' ),
+				$this->stringContains( 'cdx-message--error' )
 			)
 		);
 

--- a/tests/parser/parserTests.txt
+++ b/tests/parser/parserTests.txt
@@ -5,9 +5,9 @@ Embed function should not render when it is disabled
 !! config
 wgExternalContentEnableEmbedFunction=false
 !! wikitext
-{{#embed:raw.githubusercontent.com/ProfessionalWiki/ExternalContent/master/README.md}}
+{{#embed:https://raw.githubusercontent.com/ProfessionalWiki/ExternalContent/master/README.md}}
 !! html
-<p>{{#embed:raw.githubusercontent.com/ProfessionalWiki/ExternalContent/master/README.md}}
+<p>{{#embed:https://raw.githubusercontent.com/ProfessionalWiki/ExternalContent/master/README.md}}
 </p>
 !! end
 
@@ -16,9 +16,9 @@ Bitbucket function should not render when it is disabled
 !! config
 wgExternalContentEnableBitbucketFunction=false
 !! wikitext
-{{#bitbucket:raw.githubusercontent.com/ProfessionalWiki/ExternalContent/master/README.md}}
+{{#bitbucket:https://raw.githubusercontent.com/ProfessionalWiki/ExternalContent/master/README.md}}
 !! html
-<p>{{#bitbucket:raw.githubusercontent.com/ProfessionalWiki/ExternalContent/master/README.md}}
+<p>{{#bitbucket:https://raw.githubusercontent.com/ProfessionalWiki/ExternalContent/master/README.md}}
 </p>
 !! end
 

--- a/tests/parser/parserTests.txt
+++ b/tests/parser/parserTests.txt
@@ -1,13 +1,13 @@
-!! Version 3
+!! Version 2
 
 !! test
 Embed function should not render when it is disabled
 !! config
 wgExternalContentEnableEmbedFunction=false
 !! wikitext
-{{#embed:https://raw.githubusercontent.com/ProfessionalWiki/ExternalContent/master/README.md}}
+{{#embed:raw.githubusercontent.com/ProfessionalWiki/ExternalContent/master/README.md}}
 !! html
-<p>{{#embed:https://raw.githubusercontent.com/ProfessionalWiki/ExternalContent/master/README.md}}
+<p>{{#embed:raw.githubusercontent.com/ProfessionalWiki/ExternalContent/master/README.md}}
 </p>
 !! end
 
@@ -16,9 +16,9 @@ Bitbucket function should not render when it is disabled
 !! config
 wgExternalContentEnableBitbucketFunction=false
 !! wikitext
-{{#bitbucket:https://raw.githubusercontent.com/ProfessionalWiki/ExternalContent/master/README.md}}
+{{#bitbucket:raw.githubusercontent.com/ProfessionalWiki/ExternalContent/master/README.md}}
 !! html
-<p>{{#bitbucket:https://raw.githubusercontent.com/ProfessionalWiki/ExternalContent/master/README.md}}
+<p>{{#bitbucket:raw.githubusercontent.com/ProfessionalWiki/ExternalContent/master/README.md}}
 </p>
 !! end
 

--- a/tests/parser/parserTests.txt
+++ b/tests/parser/parserTests.txt
@@ -1,4 +1,4 @@
-!! Version 2
+!! Version 3
 
 !! test
 Embed function should not render when it is disabled
@@ -29,7 +29,7 @@ wgLanguageCode="en"
 !! wikitext
 {{#embed:https://localhost/this-does-not-exist.md}}
 !! html
-<div class="mw-message-box-error mw-message-box">Could not retrieve file</div>
+<div class="cdx-message cdx-message--block cdx-message--error"><span class="cdx-message__icon"></span><div class="cdx-message__content">Could not retrieve file</div></div>
 !! end
 
 !! test
@@ -39,7 +39,7 @@ wgLanguageCode="en"
 !! wikitext
 {{#bitbucket:https://localhost/not-a-valid-bitbucket-url.md}}
 !! html
-<div class="mw-message-box-error mw-message-box">Not a valid Bitbucket URL</div>
+<div class="cdx-message cdx-message--block cdx-message--error"><span class="cdx-message__icon"></span><div class="cdx-message__content">Not a valid Bitbucket URL</div></div>
 !! end
 
 !! test
@@ -49,5 +49,5 @@ wgExternalContentFileExtensionWhitelist=["md"]
 !! wikitext
 {{#embed:https://localhost/whatever.hax}}
 !! html
-<div class="mw-message-box-error mw-message-box">Embedding files with this extension is not allowed</div>
+<div class="cdx-message cdx-message--block cdx-message--error"><span class="cdx-message__icon"></span><div class="cdx-message__content">Embedding files with this extension is not allowed</div></div>
 !! end


### PR DESCRIPTION
Key changes
- Fix tests that are broken on 1.43
- Add CI for MW 1.39+ and PHP 8.1+
- Drop tests for MW 1.35
- Refactor install MW step to use the same implementation as other repo
- Update GitHub Actions versions in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an automated installation tool that streamlines MediaWiki setup, including extension configuration and enhanced debugging features.
- **Bug Fixes**
  - Revised error message formatting for media embedding issues, ensuring users receive clearer, more consistent feedback when problems occur.
- **Documentation**
  - Updated platform requirements to reflect compatibility with newer PHP (up to 8.3) and MediaWiki (up to 1.43) versions.
- **Improvements**
  - Enhanced CI pipeline flexibility with expanded version support and improved error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->