### PR TITLE
Fix various code styles and CI issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Parameters: none
 Platform requirements:
 
 * [PHP] 8.0 or later (tested up to 8.3)
-* [MediaWiki] 1.35 or later (tested up to 1.43 and master)
+* [MediaWiki] 1.39 or later (tested up to 1.43 and master)
 
 The recommended way to install External Content is using [Composer] with
 [MediaWiki's built-in support for Composer][Composer install].
@@ -243,6 +243,10 @@ Alternatively, you can execute commands from the MediaWiki root directory:
 * Psalm: `php vendor/bin/psalm --config=extensions/ExternalContent/psalm.xml`
 
 ## Release notes
+
+### Version 3.0.0 - 2025-02-25
+
+* Bump minimum MediaWiki requirements to 1.39 
 
 ### Version 2.0.1 - 2023-11-02
 

--- a/README.md
+++ b/README.md
@@ -244,9 +244,9 @@ Alternatively, you can execute commands from the MediaWiki root directory:
 
 ## Release notes
 
-### Version 3.0.0 - 2025-02-25
+### Version 3.0.0 - TBD
 
-* Bump minimum MediaWiki requirements to 1.39 
+* Bumped minimum MediaWiki requirements to 1.39
 
 ### Version 2.0.1 - 2023-11-02
 

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
 		"ezyang/htmlpurifier": "~4.13"
 	},
 	"require-dev": {
-		"vimeo/psalm": "*",
+		"vimeo/psalm": "^4.30.0",
 		"phpstan/phpstan": "^2.0.2",
 		"mediawiki/mediawiki-codesniffer": "45.0.0"
 	},

--- a/composer.json
+++ b/composer.json
@@ -37,8 +37,8 @@
 	},
 	"require-dev": {
 		"vimeo/psalm": "^4.10",
-		"phpstan/phpstan": "^0.12.99",
-		"mediawiki/mediawiki-codesniffer": "37.0.0"
+		"phpstan/phpstan": "^2.0.1",
+		"mediawiki/mediawiki-codesniffer": "45.0.0"
 	},
 	"config": {
 		"allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
 	},
 	"config": {
 		"allow-plugins": {
-			"composer/installers": true
+			"composer/installers": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
 		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,8 @@
 		"ezyang/htmlpurifier": "~4.13"
 	},
 	"require-dev": {
-		"vimeo/psalm": "^4.10",
-		"phpstan/phpstan": "^2.0.1",
+		"vimeo/psalm": "*",
+		"phpstan/phpstan": "^2.0.2",
 		"mediawiki/mediawiki-codesniffer": "45.0.0"
 	},
 	"config": {

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "External Content",
-	"version": "2.0.1",
+	"version": "3.0.0",
 	"license-name": "GPL-2.0-or-later",
 
 	"author": [
@@ -13,7 +13,7 @@
 	"descriptionmsg": "external-content-desc",
 
 	"requires": {
-		"MediaWiki": ">= 1.35.0",
+		"MediaWiki": ">= 1.39.0",
 		"platform": {
 			"php": ">= 8.0"
 		}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,3 +7,5 @@ parameters:
 		- ../../includes
 		- ../../tests/phpunit
 		- ../../vendor
+	bootstrapFiles:
+		- ../../includes/AutoLoader.php

--- a/src/Adapters/FileFetcher/MediaWikiFileFetcher.php
+++ b/src/Adapters/FileFetcher/MediaWikiFileFetcher.php
@@ -13,7 +13,7 @@ class MediaWikiFileFetcher implements FileFetcher {
 	private HttpRequestFactory $requestFactory;
 	private DomainCredentials $credentials;
 
-	public function __construct( HttpRequestFactory $requestFactory, DomainCredentials $credentials = null ) {
+	public function __construct( HttpRequestFactory $requestFactory, ?DomainCredentials $credentials = null ) {
 		$this->requestFactory = $requestFactory;
 		$this->credentials = $credentials ?? new DomainCredentials();
 	}

--- a/src/Domain/ContentRenderer/MarkdownRenderer.php
+++ b/src/Domain/ContentRenderer/MarkdownRenderer.php
@@ -20,7 +20,7 @@ class MarkdownRenderer implements ContentRenderer {
 		$parser = new MarkdownExtra();
 		$urlExpander = new UrlExpander();
 
-		$parser->url_filter_func = fn( string $url ) => $urlExpander->expand( $url, $contentUrl );
+		$parser->url_filter_func = fn ( string $url ) => $urlExpander->expand( $url, $contentUrl );
 
 		return $parser;
 	}

--- a/src/Domain/UrlNormalizer/BitbucketUrlNormalizer.php
+++ b/src/Domain/UrlNormalizer/BitbucketUrlNormalizer.php
@@ -29,7 +29,9 @@ class BitbucketUrlNormalizer implements UrlNormalizer {
 			$urlParts[5] = 'raw';
 		}
 
-		$urlParts[6] = ( $urlParts[6] ?? '' ) === '' ? 'README.md' : $urlParts[6];
+		if ( !isset( $urlParts[6] ) || $urlParts[6] === '' ) {
+			$urlParts[6] = 'README.md';
+		}
 
 		return implode( '/', $urlParts );
 	}

--- a/src/Domain/UrlNormalizer/BitbucketUrlNormalizer.php
+++ b/src/Domain/UrlNormalizer/BitbucketUrlNormalizer.php
@@ -29,9 +29,7 @@ class BitbucketUrlNormalizer implements UrlNormalizer {
 			$urlParts[5] = 'raw';
 		}
 
-		if ( !isset( $urlParts[6] ) || $urlParts[6] === '' ) {
-			$urlParts[6] = 'README.md';
-		}
+		$urlParts[6] = ( $urlParts[6] ?? '' ) === '' ? 'README.md' : $urlParts[6];
 
 		return implode( '/', $urlParts );
 	}

--- a/src/Domain/UrlNormalizer/BitbucketUrlNormalizer.php
+++ b/src/Domain/UrlNormalizer/BitbucketUrlNormalizer.php
@@ -11,7 +11,7 @@ class BitbucketUrlNormalizer implements UrlNormalizer {
 	public function fullNormalize( string $url ): string {
 		return ( new HostAndPathModifier() )->modifyPath(
 			$url,
-			fn( string $host, string $path ) => [ $host, $this->normalizePath( $path, true ) ]
+			fn ( string $host, string $path ) => [ $host, $this->normalizePath( $path, true ) ]
 		);
 	}
 
@@ -51,7 +51,7 @@ class BitbucketUrlNormalizer implements UrlNormalizer {
 	public function viewLevelNormalize( string $url ): string {
 		return ( new HostAndPathModifier() )->modifyPath(
 			$url,
-			fn( string $host, string $path ) => [ $host, $this->normalizePath( $path, false ) ]
+			fn ( string $host, string $path ) => [ $host, $this->normalizePath( $path, false ) ]
 		);
 	}
 

--- a/src/Domain/UrlNormalizer/GitHubUrlNormalizer.php
+++ b/src/Domain/UrlNormalizer/GitHubUrlNormalizer.php
@@ -49,8 +49,7 @@ class GitHubUrlNormalizer implements UrlNormalizer {
 
 		if ( $removeBlobSegment ) {
 			unset( $urlParts[3] );
-		}
-		elseif ( $urlParts[3] === '' ) {
+		} elseif ( $urlParts[3] === '' ) {
 			$urlParts[3] = 'blob';
 		}
 

--- a/src/Domain/UrlNormalizer/HostAndPathModifier.php
+++ b/src/Domain/UrlNormalizer/HostAndPathModifier.php
@@ -38,7 +38,10 @@ class HostAndPathModifier {
 		$port = isset( $parsedUrl['port'] ) ? ':' . $parsedUrl['port'] : '';
 		$user = $parsedUrl['user'] ?? '';
 		$pass = isset( $parsedUrl['pass'] ) ? ':' . $parsedUrl['pass'] : '';
-		$pass = ( $user || $pass ) ? "$pass@" : '';
+		
+		// Use strict comparison to check if user or pass exists
+		$pass = ( $user !== '' || $pass !== '' ) ? "$pass@" : '';
+		
 		$path = $parsedUrl['path'] ?? '';
 		$query = isset( $parsedUrl['query'] ) ? '?' . $parsedUrl['query'] : '';
 		$fragment = isset( $parsedUrl['fragment'] ) ? '#' . $parsedUrl['fragment'] : '';

--- a/src/Domain/UrlNormalizer/HostAndPathModifier.php
+++ b/src/Domain/UrlNormalizer/HostAndPathModifier.php
@@ -38,8 +38,7 @@ class HostAndPathModifier {
 		$port = isset( $parsedUrl['port'] ) ? ':' . $parsedUrl['port'] : '';
 		$user = $parsedUrl['user'] ?? '';
 		$pass = isset( $parsedUrl['pass'] ) ? ':' . $parsedUrl['pass'] : '';
-		
-		// Use strict comparison to check if user or pass exists
+
 		$pass = ( $user !== '' || $pass !== '' ) ? "$pass@" : '';
 		
 		$path = $parsedUrl['path'] ?? '';

--- a/src/EntryPoints/MediaWikiHooks.php
+++ b/src/EntryPoints/MediaWikiHooks.php
@@ -18,7 +18,7 @@ final class MediaWikiHooks {
 		if ( self::embedFunctionIsEnabled() ) {
 			$parser->setFunctionHook(
 				'embed',
-				fn( Parser $parser, string ...$arguments )
+				fn ( Parser $parser, string ...$arguments )
 					=> ( new EmbedFunction() )->handleParserFunctionCall( $parser, ...$arguments )
 			);
 		}
@@ -26,7 +26,7 @@ final class MediaWikiHooks {
 		if ( self::bitbucketFunctionIsEnabled() ) {
 			$parser->setFunctionHook(
 				'bitbucket',
-				fn( Parser $parser, string ...$arguments )
+				fn ( Parser $parser, string ...$arguments )
 					=> ( new BitbucketFunction() )->handleParserFunctionCall( $parser, ...$arguments )
 			);
 		}

--- a/src/UseCases/Embed/EmbedUseCase.php
+++ b/src/UseCases/Embed/EmbedUseCase.php
@@ -42,8 +42,7 @@ class EmbedUseCase {
 	public function embed( EmbedRequest $request ): void {
 		try {
 			$normalizedUrl = $this->urlNormalizer->fullNormalize( $request->fileUrl );
-		}
-		catch ( \RuntimeException $exception ) {
+		} catch ( \RuntimeException $exception ) {
 			$this->presenter->showError( $exception->getMessage() );
 			return;
 		}
@@ -57,8 +56,7 @@ class EmbedUseCase {
 
 		try {
 			$content = $this->fileFetcher->fetchFile( $normalizedUrl );
-		}
-		catch ( \Exception $exception ) {
+		} catch ( \Exception $exception ) {
 			$this->presenter->showFetchingError();
 			return;
 		}

--- a/tests/Unit/Adapters/MediaWikiFileFetcherTest.php
+++ b/tests/Unit/Adapters/MediaWikiFileFetcherTest.php
@@ -21,7 +21,7 @@ class MediaWikiFileFetcherTest extends TestCase {
 	public function testWhenRequestFactoryReturnsNull_exceptionIsThrown(): void {
 		$requestFactory = $this->createMock( HttpRequestFactory::class );
 		$requestFactory->method( 'get' )
-			->with( $this->equalTo( 'https://example.com' ) )
+			->with( 'https://example.com' )
 			->willReturn( null );
 
 		$this->expectException( FileFetchingException::class );
@@ -31,7 +31,7 @@ class MediaWikiFileFetcherTest extends TestCase {
 	public function testWhenRequestFactoryReturnsString_itIsReturned(): void {
 		$requestFactory = $this->createMock( HttpRequestFactory::class );
 		$requestFactory->method( 'get' )
-			->with( $this->equalTo( 'https://example.com' ) )
+			->with( 'https://example.com' )
 			->willReturn( '~=[,,_,,]:3' );
 
 		$this->assertSame(
@@ -45,7 +45,7 @@ class MediaWikiFileFetcherTest extends TestCase {
 		$requestFactory->expects( $this->once() )
 			->method( 'get' )
 			->with(
-				$this->equalTo( 'https://example.com' ),
+				'https://example.com',
 				$this->equalTo( [
 					'username' => 'FooUser',
 					'password' => 'BarPassword'
@@ -65,8 +65,8 @@ class MediaWikiFileFetcherTest extends TestCase {
 		$requestFactory->expects( $this->once() )
 			->method( 'get' )
 			->with(
-				$this->equalTo( 'https://example.com' ),
-				$this->equalTo( [] )
+				'https://example.com',
+				[]
 			)->willReturn( '~=[,,_,,]:3' );
 
 		$domainCredentials = new DomainCredentials();


### PR DESCRIPTION
Follow up to #65

- Bump minimum MW requirement to 1.39
- Fix various code styles issues raised by CI
- Add bootstrap file for phpstan
- Bump phpstan from `^0.12.99` to `^2.0.2`
- Bump psalm from from `^4.10` to `^4.30.0`
- Bump mediawiki/mediawiki-codesniffer from `37.0.0` to `45.0.0`
- Allow `dealerdirect/phpcodesniffer-composer-installer` composer plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
  - Updated release notes for version 3.0.0 and revised platform requirements to MediaWiki 1.39 or later.
- **Chores**
  - Upgraded development dependencies, including `vimeo/psalm`, `phpstan/phpstan`, and `mediawiki/mediawiki-codesniffer`.
  - Refined configuration settings for allowed plugins.
  - Applied minor code-style improvements in various files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->